### PR TITLE
Added tests and updated training file for a few MAC surnames. Closes #22

### DIFF
--- a/name_data/labeled/labeled.xml
+++ b/name_data/labeled/labeled.xml
@@ -3892,4 +3892,6 @@
   </Name>
   <Name><GivenName>Alek</GivenName> <Surname>Klebaner</Surname> <SuffixOther>DDS</SuffixOther></Name>
   <Name><CorporationName>ALEX</CorporationName> <CorporationName>DISPLAYS</CorporationName> <CorporationNameAndCompany>&amp;</CorporationNameAndCompany> <CorporationNameAndCompany>CO</CorporationNameAndCompany> <CorporationLegalType>INC</CorporationLegalType></Name>
+  <Name><GivenName>Cindy</GivenName> <Surname>Mac</Surname> <Surname>Kendrick</Surname></Name>
+  <Name><GivenName>Richard</GivenName> <Surname>Mac</Surname> <Surname>Pherson</Surname></Name>
 </NameCollection>

--- a/tests/test_data_labeled.xml
+++ b/tests/test_data_labeled.xml
@@ -43,6 +43,8 @@
   <Name><Surname>MILLER,</Surname> <GivenName>JENICE</GivenName></Name>
   <Name><Surname>AGYEKUM,</Surname> <GivenName>KOFI</GivenName></Name>
   <Name><GivenName>Devika</GivenName> <Surname>Subramanian</Surname></Name>
+  <Name><GivenName>CINDY</GivenName> <Surname>MAC</Surname> <Surname>KENDRICK</Surname></Name>
+  <Name><GivenName>RICHARD</GivenName> <Surname>MAC</Surname> <Surname>PHERSON</Surname></Name>
   <Name><CorporationName>NOVAMED</CorporationName> <CorporationName>MANAGEMENT</CorporationName> <CorporationName>SERVICES,</CorporationName> <CorporationLegalType>LLC</CorporationLegalType></Name>
   <Name><CorporationName>GRAND</CorporationName> <CorporationName>LUX</CorporationName> <CorporationName>CAFE</CorporationName> <CorporationLegalType>LLC</CorporationLegalType></Name>
   <Name><CorporationName>LEZ</CorporationName> <CorporationName>ENFANTS</CorporationName> <CorporationName>ACADEMY,</CorporationName> <CorporationLegalType>INC.</CorporationLegalType></Name>


### PR DESCRIPTION
I have added the necessary tests and additions to the name_data/labeled/labeled.xml file.

There were only two, out of the 25 or so example names that I provided, which were failing.

My error was using the failures on names that came from the web based version that you host. It appears that the web based version might have an out of date training file since many of the names that failed there actually pass in the current build.

This PR allows the training file to handle surnames like "MAC KENDRICK" and "MAC PHERSON" correctly.
