### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Try it out on our [web interface](https://parserator.datamade.us/probablepeople)
 probablepeople learns how to parse names/companies through a body of training data. If you have examples of names/companies that stump this parser, please send them over! By adding more examples to the training data, probablepeople can continue to learn and improve.
 
 ## How to use the probablepeople python library
-1. Install probablepeople with [pip](http://pip.readthedocs.org/en/latest/quickstart.html), a tool for installing and managing python packages ([beginner's guide here](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/))
+1. Install probablepeople with [pip](https://pip.readthedocs.io/en/latest/quickstart.html), a tool for installing and managing python packages ([beginner's guide here](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/))
 
    In the terminal,
    
@@ -41,7 +41,7 @@ probablepeople learns how to parse names/companies through a body of training da
    ```
 
 ## Links:
-* Documentation: http://probablepeople.rtfd.org/
+* Documentation: https://probablepeople.readthedocs.io/
 * Web Interface: http://parserator.datamade.us/probablepeople
 * Distribution: https://pypi.python.org/pypi/probablepeople
 * Repository: https://github.com/datamade/probablepeople

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,7 +130,7 @@ probablepeople has the following labels for parsing names & companies:
 Important links
 ===============
 
-* Documentation: http://probablepeople.rtfd.org/
+* Documentation: https://probablepeople.readthedocs.io/
 * Repository: https://github.com/datamade/probablepeople
 * Issues: https://github.com/datamade/probablepeople/issues
 * Distribution: https://pypi.python.org/pypi/probablepeople

--- a/probablepeople/__init__.py
+++ b/probablepeople/__init__.py
@@ -273,4 +273,4 @@ def ngrams(word, n=2):
 
 class RepeatedLabelError(probableparsing.RepeatedLabelError) :
     REPO_URL = 'https://github.com/datamade/probablepeople/issues/new'
-    DOCS_URL = 'http://probablepeople.readthedocs.org/'
+    DOCS_URL = 'https://probablepeople.readthedocs.io/'


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
