### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Add the `LICENSE` to `MANIFEST.in` so that it will be included in sdists and other packages. This came up during packaging of probablepeople for conda-forge.

Also please submit a new release to pypi so this change will be tracked. 
