### PR TITLE
Lower startup memory usage by loading huge dictionaries from JSON files

### DIFF
--- a/probablepeople/__init__.py
+++ b/probablepeople/__init__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 
+import json
 import os
+import os.path
 import re
 import string
 import typing
@@ -10,8 +12,16 @@ import probableparsing
 import pycrfsuite
 from doublemetaphone import doublemetaphone
 
-from .gender import gender_names
-from .ratios import ratios
+
+def _loadJsonDictionary(name):
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+    ) as input_file:
+        return json.load(input_file)
+
+
+gender_names = _loadJsonDictionary("gender_names.json")
+ratios = _loadJsonDictionary("ratios.json")
 
 Feature = dict[str, typing.Union[str, bool, "Feature"]]
 
@@ -120,7 +130,6 @@ def tag(
     )
 
     for token, label in parse(raw_string, type):
-
         if label == "And":
             and_label = True
         elif label == "AKA":
@@ -165,7 +174,6 @@ def tag(
 
 
 def tokenize(raw_string: str) -> list[str]:
-
     if isinstance(raw_string, bytes):
         raw_string = raw_string.decode()
 
@@ -189,7 +197,6 @@ def tokenize(raw_string: str) -> list[str]:
 
 
 def tokens2features(tokens) -> list[Feature]:
-
     feature_sequence = [tokenFeatures(tokens[0])]
     previous_features = feature_sequence[-1].copy()
 
@@ -224,7 +231,6 @@ def tokens2features(tokens) -> list[Feature]:
 
 
 def tokenFeatures(token: str) -> Feature:
-
     if token in ("&"):
         token_clean = token_abbrev = token
 

--- a/probablepeople/gender_names.json
+++ b/probablepeople/gender_names.json
@@ -1,4 +1,4 @@
-gender_names = {
+{
     "aaron": 0.008264462809917357,
     "abbey": 1.0,
     "abbie": 1.0,
@@ -5161,5 +5161,5 @@ gender_names = {
     "zoraida": 1.0,
     "zula": 1.0,
     "zulema": 1.0,
-    "zulma": 1.0,
+    "zulma": 1.0
 }

--- a/probablepeople/ratios.json
+++ b/probablepeople/ratios.json
@@ -1,4 +1,4 @@
-ratios = {
+{
     "AA": 0,
     "AAB": 0,
     "AABERG": 0,
@@ -154290,5 +154290,5 @@ ratios = {
     "ZYSKOWSKI": 0,
     "ZYSMAN": 0,
     "ZYWICKI": 0,
-    "ZYWIEC": 0,
+    "ZYWIEC": 0
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ include = ["probablepeople"]
 [tool.setuptools.package-data]
 probablepeople = ["generic_learned_settings.crfsuite",
                   "person_learned_settings.crfsuite",
-                  "company_learned_settings.crfsuite"
+                  "company_learned_settings.crfsuite",
+                  "gender_names.json",
+                  "ratios.json",
 ]
 
 


### PR DESCRIPTION
Refactors initialization to load "ratio" and "gender_names" dictionary data from JSON instead of using giant static Python dictionaries.

When we originally added `probablepeople` to our Flask application, it increased our app's peak memory footprint by 600MB during startup, causing OOM errors in our deployment infrastructure. Following [a suggestion from a related issue](https://github.com/microsoft/ptvsd/issues/1288#issuecomment-480924596), and [also taking inspiration from another fork](https://github.com/goodkiwillc/probablepeople/commit/d6a1ed7ff9b9103d67ce4802d2869f5958a900e8), this eliminates the 600MB spike by loading the dictionary data from a JSON file.

I've taken a simple approach that attempts to minimize code changes, basically converting the two dictionary `.py` files to `.json` and loading at import-time. But certainly open to suggestions, as there are many ways to skin this cat.